### PR TITLE
Don't download if activator already exists

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,10 @@
 ---
-- name: Download Typesafe Activator
-  get_url: url={{ typesafe_activator_url }} dest="/tmp/{{ typesafe_activator_archive }}"
-
 - stat: path='/opt/activator-dist-{{ typesafe_activator_version }}'
   register: activatordir
+  
+- name: Download Typesafe Activator
+  when: activatordir.stat.exists == false
+  get_url: url={{ typesafe_activator_url }} dest="/tmp/{{ typesafe_activator_archive }}"
 
 - name: Unzip Typesafe Activator
   when: activatordir.stat.exists == false


### PR DESCRIPTION
Rerunning this role would always cause a download, even if everything is already installed.
